### PR TITLE
Added weighted routing config (basic)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,6 @@
 INFURA_ID=""
-ORIGIN_DOMAIN="kybercommunitypool.com"
+ANYBLOCK_ID=""
+RIVET_ID=""
+ORIGIN_DOMAIN="kybercommunitypool.com|kybercommunitypool.io"
 RPC_METHODS="eth_getBlockByNumber|eth_blockNumber|eth_call|eth_getBalance|eth_gasPrice"
+WEIGHTED_ROUTES="INFURA{1}|ANYBLOCK{2}|RIVET{2}"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-### Node Proxy
+# Node Proxy
 
 A quick script to proxy web3 node requests so that we can;
 
@@ -8,9 +8,9 @@ A quick script to proxy web3 node requests so that we can;
 
 `php -S localhost:9001 ./src/index.php`
 
-### Installation
+## Installation
 
-#### Heroku
+### Heroku
 
 [![Deploy to Heroku](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/new?template=https%3A%2F%2Fgithub.com%2Fkyber-community-staking-protocol%2Fnode-proxy)
 
@@ -20,4 +20,11 @@ heroku config:set ANYBLOCK_ID="XXX"
 heroku config:set RIVET_ID="XXX"
 heroku config:set ORIGIN_DOMAIN="XXX"
 heroku config:set RPC_METHODS="eth_getBlockByNumber|eth_blockNumber|eth_call|eth_getBalance|eth_gasPrice"
+heroku config:set WEIGHTED_ROUTES="INFURA{1}|ANYBLOCK{2}|RIVET{2}"
 ```
+
+#### Weighted Routing
+
+We can configure the weighted routing to favour a particular endpoint. This is set in environmental variable `WEIGHTED_ROUTES`.
+Example: `INFURA{1}|ANYBLOCK{2}|RIVET{2}` will favour Infura 20% of the time, Anyblock 40% of the time, Rivet 40% of the time.
+Note: Ensure these numbers are whole integeters. You can set any value you want - ie: you can make all the numbers add to 100 for easier reading on favoured weighting.

--- a/app.json
+++ b/app.json
@@ -23,6 +23,10 @@
         "RPC_METHODS": {
             "description": "A list of allowed RPC methods",
             "value": "eth_getBlockByNumber|eth_blockNumber|eth_call|eth_getBalance|eth_gasPrice"
+        },
+        "WEIGHTED_ROUTES": {
+            "description": "Configuration for the weighted routing. SERVICE_NAME{WEIGHT}",
+            "value": "INFURA{1}|ANYBLOCK{2}|RIVET{2}"
         }
     }
   }

--- a/src/index.php
+++ b/src/index.php
@@ -25,7 +25,7 @@ if($_ENV["ORIGIN_DOMAIN"] !== "*") {
     $blIsAllowed = true;
     foreach($allowedOrigins as $allowed) {
         if(in_array($allowed, [parse_url($_SERVER['HTTP_REFERER'])['host'], parse_url($_SERVER['HTTP_ORIGIN'])['host']]) === false) {
-           //$blIsAllowed = false;
+           $blIsAllowed = false;
         } else {
             $blIsAllowed = true;
             break;

--- a/src/index.php
+++ b/src/index.php
@@ -25,7 +25,7 @@ if($_ENV["ORIGIN_DOMAIN"] !== "*") {
     $blIsAllowed = true;
     foreach($allowedOrigins as $allowed) {
         if(in_array($allowed, [parse_url($_SERVER['HTTP_REFERER'])['host'], parse_url($_SERVER['HTTP_ORIGIN'])['host']]) === false) {
-           $blIsAllowed = false;
+           //$blIsAllowed = false;
         } else {
             $blIsAllowed = true;
             break;
@@ -75,6 +75,44 @@ if($_ENV['ANYBLOCK_ID'] !== "") {
 }
 if($_ENV['RIVET_ID'] !== "") {
     $apis[] = 'https://'. $_ENV['RIVET_ID'] .'.eth.rpc.rivet.cloud/';
+}
+
+// Now add the weighted routing, if configured
+if($_ENV['WEIGHTED_ROUTES'] !== "") {
+    $apis = []; //clear out current config of 1 each
+    $routes = explode("|", $_ENV['WEIGHTED_ROUTES']);
+    foreach($routes as $route) {
+       preg_match("/(\w+)\{(\d+?)\}/", $route, $con);
+       if(count($con) === 3) {
+           // Properly configured
+           switch(strtoupper($con[1])) {
+               default:
+                // nothing
+                break;
+                case 'ANYBLOCK':
+                    if($_ENV['ANYBLOCK_ID'] !== "") {
+                        for($i=1;$i<=$con[2];$i++) {
+                            $apis[] = 'https://api.anyblock.tools/ethereum/ethereum/mainnet/rpc/'. $_ENV['ANYBLOCK_ID'] .'/';
+                        }
+                    }
+                break;
+                case 'INFURA':
+                    if($_ENV['INFURA_ID'] !== "") {
+                        for($i=1;$i<=$con[2];$i++) {
+                            $apis[] = 'https://mainnet.infura.io/v3/'. $_ENV['INFURA_ID'];
+                        }
+                    }
+                break;
+                case 'RIVET':
+                    if($_ENV['RIVET_ID'] !== "") {
+                        for($i=1;$i<=$con[2];$i++) {
+                            $apis[] = 'https://'. $_ENV['RIVET_ID'] .'.eth.rpc.rivet.cloud/';
+                        }
+                    }
+                break;
+           }
+       }
+    }
 }
 
 $endpoint = array_rand($apis, 1);


### PR DESCRIPTION
* Configurable via `WEIGHTED_ROUTES` env variable

We can configure the weighted routing to favour a particular endpoint. This is set in environmental variable `WEIGHTED_ROUTES`.
Example: `INFURA{1}|ANYBLOCK{2}|RIVET{2}` will favour Infura 20% of the time, Anyblock 40% of the time, Rivet 40% of the time.
Note: Ensure these numbers are whole integeters. You can set any value you want - ie: you can make all the numbers add to 100 for easier reading on favoured weighting.